### PR TITLE
チャート削除機能の実装

### DIFF
--- a/src/app/Http/Controllers/ChartController.php
+++ b/src/app/Http/Controllers/ChartController.php
@@ -135,6 +135,29 @@ class ChartController extends Controller
     }
   }
 
+  public function reachDelete(Request $req): JsonResponse
+  {
+    $validator = Validator::make($req->all(), [
+      'id' => 'required|numeric',
+      'userEmail' => 'required|email|max:255',
+    ]);
+    if ($validator->fails()) {
+      return response()->json([
+        'errors' => $validator->errors('idとuserEmailの値が正しくありません。')
+      ], 422);
+    }
+    try {
+      $actions = Action::where(['reach_id'=>$req->id])->delete();
+      $skills = Skill::where(['reach_id'=>$req->id])->delete();
+      $reach = Reach::where(['id'=>$req->id])->delete();
+      return response()->json($actions);
+    } catch (Exception $e) {
+      return response()->json([
+        'error'=>$e->getMessage()
+      ]);
+    }
+    return response()->json('reach delete!!!!!');
+  }
 
   public function skillEdit(Request $req): JsonResponse
   {

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -30,6 +30,7 @@ Route::prefix('/myChart')
 		Route::post('/create', 'store')->name('store');
 
 		Route::patch('/reach/{id}', 'reachPatch')->name('reachPatch');
+		Route::delete('/reach/{id}', 'reachDelete')->name('reachDelete');
 
 		Route::post('/reach/skill/{skillName}', 'skillEdit')->name('skillEdit');
 		Route::patch('/reach/skill/{skillName}', 'skillPatch')->name('skillPatch');


### PR DESCRIPTION
1. apiルートの作成[api/myChart/reach/{reach_id}]として作成
2. リーチの削除のため、アクション削除、スキル削除、リーチ削除の手順で実装